### PR TITLE
Document v0.1.0 release

### DIFF
--- a/.llm-wiki/memory/known-issues.md
+++ b/.llm-wiki/memory/known-issues.md
@@ -31,5 +31,5 @@ The MVP has deterministic foundations but still lacks full diff synthesis and ex
 - Conflict detection is metadata and keyword based, not semantic.
 - Marketplace publishing metadata can be expanded later.
 - The name "Dixie Flatline" has public non-software associations and should be treated as a deliberate branding decision before launch.
-- GitHub secret scanning was not available for the private repository at the time of the public-readiness pass.
-- GitHub branch protection was not available while the repository remained private on the current plan; enable it immediately after making the repository public.
+- GitHub secret scanning and push protection were enabled after the repository became public.
+- GitHub branch protection was enabled after the repository became public.

--- a/.llm-wiki/memory/known-issues.md
+++ b/.llm-wiki/memory/known-issues.md
@@ -31,5 +31,5 @@ The MVP has deterministic foundations but still lacks full diff synthesis and ex
 - Conflict detection is metadata and keyword based, not semantic.
 - Marketplace publishing metadata can be expanded later.
 - The name "Dixie Flatline" has public non-software associations and should be treated as a deliberate branding decision before launch.
-- GitHub secret scanning and push protection were enabled after the repository became public.
-- GitHub branch protection was enabled after the repository became public.
+- GitHub secret scanning and push protection must remain enabled because the repository became public before those protections were in place.
+- GitHub branch protection must remain enabled because the repository became public before that protection was in place.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Experimental VS Code extension for repo-local AI memory.
 
 Not production-ready. APIs and schema may change.
 
+If you want to try it without building from source, install a VSIX from GitHub Releases.
+
 ```mermaid
 flowchart TD
   Extension["VS Code Extension"]
@@ -56,7 +58,28 @@ apps/
       tools/
 ```
 
-## Getting Started
+## Try A Release Build
+
+Download a `.vsix` asset from [GitHub Releases](https://github.com/CambridgeMonorail/dixie-flatline/releases).
+
+- For the current public build, use [v0.1.0](https://github.com/CambridgeMonorail/dixie-flatline/releases/tag/v0.1.0).
+- For dev builds, look for releases marked `Pre-release` and download the attached `.vsix` asset.
+
+Install the downloaded VSIX with either:
+
+```bash
+code --install-extension path/to/dixie-flatline.vsix
+```
+
+Or from VS Code with `Extensions: Install from VSIX...`.
+
+Then run:
+
+```txt
+Dixie Flatline: Initialise
+```
+
+## Build From Source
 
 ```bash
 pnpm install

--- a/docs/public-launch-checklist.md
+++ b/docs/public-launch-checklist.md
@@ -1,6 +1,6 @@
 # Public Launch Checklist
 
-This repository is not public yet. Complete this checklist before changing visibility.
+This repository is already public. Keep this checklist as a record of the public-readiness pass and as an ongoing checklist for release maintenance on this repository and future public repos.
 
 ## Current Status
 
@@ -19,7 +19,7 @@ This repository is not public yet. Complete this checklist before changing visib
 - Generated artifacts: `dist/`, `.nx/`, `coverage/`, and `*.vsix` are ignored
 - Private memory: current `.llm-wiki/` entries are project memory for Dixie Flatline itself and are intended to be public
 
-## Before Visibility Change
+## Ongoing Protections And Launch Checks
 
 - Confirm `.llm-wiki/` contains no private prompts, private repo memory, customer names, internal roadmap details, Slack excerpts, screenshots, or proprietary snippets.
 - Confirm ignored local artifacts are not uploaded elsewhere as release assets by accident.

--- a/docs/public-launch-checklist.md
+++ b/docs/public-launch-checklist.md
@@ -11,10 +11,11 @@ This repository is not public yet. Complete this checklist before changing visib
 - Dependency audit: `pnpm audit --audit-level moderate` reports no known vulnerabilities after dependency overrides
 - Package freshness: `pnpm outdated` returned no outdated direct dependencies
 - npm package name: `dixie-flatline` returned 404 from npm registry during lookup, so it does not appear to be published there
-- GitHub secret scanning/push protection: attempted via GitHub API, but GitHub returned `Secret scanning is not available for this repository`
-- Branch protection: attempted for `main`, but GitHub returned `Upgrade to GitHub Pro or make this repository public to enable this feature`
+- GitHub secret scanning/push protection: enabled after the repository became public
+- Branch protection: enabled after the repository became public; `main` requires `Build and test` and one approving review
 - Branding assets: logo, icon, README header, and social preview generated under `docs/brand/`
 - GitHub repo description and topics have been set. Upload `docs/brand/og-image.png` manually as the GitHub social preview before launch.
+- First release: `v0.1.0` created with `dixie-flatline-0.1.0.vsix`
 - Generated artifacts: `dist/`, `.nx/`, `coverage/`, and `*.vsix` are ignored
 - Private memory: current `.llm-wiki/` entries are project memory for Dixie Flatline itself and are intended to be public
 
@@ -22,9 +23,9 @@ This repository is not public yet. Complete this checklist before changing visib
 
 - Confirm `.llm-wiki/` contains no private prompts, private repo memory, customer names, internal roadmap details, Slack excerpts, screenshots, or proprietary snippets.
 - Confirm ignored local artifacts are not uploaded elsewhere as release assets by accident.
-- Enable GitHub secret scanning and push protection where available.
+- Keep GitHub secret scanning and push protection enabled.
 - Enable private vulnerability reporting if available.
-- Add branch protection for `main` immediately after the repository is public, requiring the `Build and test` CI check and at least one approving review.
+- Keep branch protection for `main` enabled, requiring the `Build and test` CI check and at least one approving review.
 - Confirm package and extension publishing names before publishing to npm or the VS Code Marketplace.
 - `npm audit` and `npm outdated` could not be run in the local Codex environment because `npm` is not installed with the bundled Node runtime; use pnpm results and/or run npm checks in another local Node installation if needed.
 

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -20,7 +20,7 @@ Experimental. Not production-ready. APIs and schema may change.
 
 ## Install
 
-Download `dixie-flatline-0.1.0.vsix` from this release, then install it from VS Code:
+Download `dixie-flatline-0.1.0.vsix` from the [v0.1.0 GitHub release](https://github.com/CambridgeMonorail/dixie-flatline/releases/tag/v0.1.0), then install it from VS Code:
 
 ```bash
 code --install-extension dixie-flatline-0.1.0.vsix

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,41 @@
+# Dixie Flatline v0.1.0
+
+Initial public release of Dixie Flatline.
+
+## What Is Included
+
+- Nx workspace for the VS Code extension
+- `@project-memory` chat participant
+- Copilot language-model tool declarations
+- Structured Markdown memory model
+- Importance, confidence, freshness, and supersession metadata
+- Critical decision, conflict, and open-question retrieval
+- Copilot instruction generation
+- Heuristic diff-to-memory suggestions
+- Brand assets and public project documentation
+
+## Status
+
+Experimental. Not production-ready. APIs and schema may change.
+
+## Install
+
+Download `dixie-flatline-0.1.0.vsix` from this release, then install it from VS Code:
+
+```bash
+code --install-extension dixie-flatline-0.1.0.vsix
+```
+
+Then run:
+
+```txt
+Dixie Flatline: Initialise
+```
+
+## Validation
+
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `nx package project-memory-extension`
+- GitHub Actions CI


### PR DESCRIPTION
## Summary

- add v0.1.0 release notes to the repo
- update the public launch checklist to reflect post-public protections and release state
- update project memory known issues after enabling protections

## Validation

- Release v0.1.0 already exists with the VSIX attached
- Branch protection is active, so this documentation update is going through PR flow