### PR TITLE
docs: add branch and PR validation guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,8 @@
 - Keep VS Code API imports at the extension edge so core memory modules remain unit-testable.
 - Tool contribution names in `apps/project-memory-extension/package.json` must match registrations in `src/tools/toolProvider.ts`.
 - Default retrieval and instruction compilation should prioritize critical/high importance, high confidence, and fresh verification.
+- Work on a non-`main` branch for reviewable changes; do not develop fixes or features directly on `main`.
+- Before opening or updating a pull request, run the narrowest relevant local validation for the changed surface and include that validation in the PR.
 
 ## Conventions
 

--- a/.llm-wiki/memory/git-workflow.md
+++ b/.llm-wiki/memory/git-workflow.md
@@ -1,0 +1,53 @@
+---
+id: branch-first-validation-workflow
+type: decision
+title: Work on branches and validate before opening pull requests
+summary: Changes should be developed on feature branches and validated locally before they are proposed for review.
+createdAt: 2026-05-01
+lastUpdatedAt: 2026-05-01
+lastVerifiedAt: 2026-05-01
+confidence: high
+importance: high
+relatedFiles:
+  - .github/copilot-instructions.md
+  - CONTRIBUTING.md
+  - .github/workflows/ci.yml
+tags:
+  - git
+  - workflow
+  - quality
+sources:
+  - CONTRIBUTING.md
+supersedes:
+supersededBy:
+---
+
+## Work on branches and validate before opening pull requests
+
+## Summary
+
+Changes should be developed on feature branches and validated locally before they are proposed for review.
+
+## Context
+
+The repository uses pull requests and CI as the review path for changes to `main`. Working directly on `main` increases the chance of mixing incomplete work into the default branch and makes review discipline weaker.
+
+## Decision
+
+Create or switch to a non-`main` branch before making code or documentation changes intended for review. Before opening or updating a pull request, run the narrowest relevant local validation for the changed surface and confirm it passes.
+
+## Consequences
+
+Reviewable changes stay isolated from `main`. Pull requests carry a clearer validation story. Contributors and coding agents are expected to treat local validation as part of finishing the task, not as optional follow-up.
+
+## Constraints
+
+- Do not develop reviewable changes directly on `main`.
+- Use focused validation first, then broader checks when needed.
+- Include the validation performed when raising a pull request.
+
+## Anti-Patterns
+
+- Do not make feature or fix changes on `main` and sort out branching later.
+- Do not open a pull request without running relevant local checks.
+- Do not rely on CI as the first signal that the change is broken.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,9 @@ pnpm build
 
 ## Pull Requests
 
+- Create a feature branch before making reviewable changes. Do not develop fixes or features directly on `main`.
 - Keep changes focused.
+- Run the narrowest relevant local validation before opening or updating a pull request, and include that validation in the PR description.
 - Add or update tests for behavior changes.
 - Update `.llm-wiki/memory/` when decisions, constraints, known issues, or open questions change.
 - Do not commit generated files such as `dist/`, `.nx/`, `coverage/`, or `*.vsix`.


### PR DESCRIPTION
## Summary

- add explicit branch-first workflow guidance to Copilot instructions
- add contributor guidance to avoid developing on `main`
- add a durable project-memory decision for branch and PR validation discipline

## Validation

- Verified diagnostics are clean for `.github/copilot-instructions.md`
- Verified diagnostics are clean for `CONTRIBUTING.md`
- Verified diagnostics are clean for `.llm-wiki/memory/git-workflow.md`